### PR TITLE
Add "gemini protocol in URL" check in Tab UI

### DIFF
--- a/jimmy/Tab.swift
+++ b/jimmy/Tab.swift
@@ -38,6 +38,13 @@ class Tab: ObservableObject, Hashable, Identifiable {
         if self.url.isEmpty {
             return
         }
+        
+        // When copying the link with "gemini://" in the beginning to Tab area -
+        // remove the protocol and leave only the link
+        if self.url.contains("gemini://") {
+            self.url = self.url.replacingOccurrences(of: "gemini://", with: "")
+        }
+
         if (self.url == "about") {
             if let asset = NSDataAsset(name: "home") {
                 let data = asset.data


### PR DESCRIPTION
Before, you couldn't paste a link like "gemini://example.com" into a Tab (or search bar) - it would cause an error. And now you can!

I saw that there was a [URLParser](https://github.com/jfoucher/Jimmy/blob/main/jimmy/URLParser.swift), but thought it couldn't be used in this context. Maybe I'm wrong hehe

## Screenshots

Before:
![Before](https://user-images.githubusercontent.com/44648612/154836144-aecb7aa6-b740-402b-a3a0-7494e951fdf3.png)

After:
![After](https://user-images.githubusercontent.com/44648612/154836156-22df8310-2e33-4df4-856e-621c563e5e3b.png)

